### PR TITLE
Require line length of 110 characters

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -721,7 +721,7 @@ Metrics/CyclomaticComplexity:
   Max: 6
 
 Metrics/LineLength:
-  Max: 120
+  Max: 110
   # To make it possible to copy or click on URIs in the code, we allow lines
   # contaning a URI to be longer than Max.
   AllowURI: true


### PR DESCRIPTION
In Github lines of 120 characters length were nicely displayed. In Gitlab they break and make the diffs less readable. I therefore propose a new line max length of 110 characters.